### PR TITLE
Remove `LICENSE` from `generic-diff-containers.cabal`

### DIFF
--- a/examples/containers-instances/generic-diff-containers.cabal
+++ b/examples/containers-instances/generic-diff-containers.cabal
@@ -2,7 +2,6 @@ cabal-version:      3.0
 name:               generic-diff-containers
 version:            0.1.0.0
 license:            BSD-3-Clause
-license-file:       LICENSE
 author:             Frederick Pringle
 maintainer:         freddyjepringle@gmail.com
 copyright:          Copyright(c) Frederick Pringle 2025


### PR DESCRIPTION
This was causing build issues using Nix in another project.
